### PR TITLE
Fix tensorflow toolchains

### DIFF
--- a/toolchains/java/BUILD
+++ b/toolchains/java/BUILD
@@ -8,10 +8,21 @@ load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolcha
 
 licenses(["notice"])
 
+# Java toolchain that works with JDK8 and Bazel 3.7.2, 4.0.0.
 default_java_toolchain(
     name = "tf_java_toolchain",
     jvm_opts = JDK8_JVM_OPTS,
     tools = ["@bazel_tools//tools/jdk:javac_jar"],
+    misc = [
+        "-XDskipDuplicateBridges=true",
+        "-g",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Java toolchain that works with newer JDKs (>8) or Bazel > 4.0.0.
+default_java_toolchain(
+    name = "tf_java_toolchain_jdk11",
     misc = [
         "-XDskipDuplicateBridges=true",
         "-g",

--- a/toolchains/java/BUILD
+++ b/toolchains/java/BUILD
@@ -4,12 +4,14 @@
 # 0.29.1), a warning message will be thrown if "-parameters" is passed. If "-Werror" also exists,
 # the compiling action will fail. To workaround this, we override the misc value of
 # the default java toolchain to remove "-parameters" flag.
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "JDK8_JVM_OPTS")
 
 licenses(["notice"])
 
 default_java_toolchain(
     name = "tf_java_toolchain",
+    jvm_opts = JDK8_JVM_OPTS,
+    tools = ["@bazel_tools//tools/jdk:javac_jar"],
     misc = [
         "-XDskipDuplicateBridges=true",
         "-g",


### PR DESCRIPTION
Tensorflow builds started failing on JDK8. The culprit was probably https://github.com/tensorflow/tensorflow/commit/dee97cdfb1dd1f214a9b2ef8e1ba4b16ba3f058c, which explicitly set the java_toolchain flags. The problem happens when JDK8 is the default java installation.

This PR has been manually tested with (Bazel 3.7.2, Bazel 4.0.0, Bazel@HEAD) x (JDK8, JDK11) x (change, no change). Bazel@HEAD always works. The change breaks JDK11 on Bazel 3.7.2 and Bazel 4.0.0, so I added another toolchain configuration to handle it if needed.

Related are b/183711963 and https://github.com/bazelbuild/bazel/issues/13241.
