### PR TITLE
Pin Cuda11.2 to container with Python 3.9 available

### DIFF
--- a/toolchains/remote_config/containers.bzl
+++ b/toolchains/remote_config/containers.bzl
@@ -14,7 +14,7 @@ container_digests = {
     "cuda10.1-cudnn7-ubuntu16.04-manylinux2010-multipython": "sha256:3f890a951c81a201d60d0161a56ce628a90323be0c7f795550caa37f6f41a85c",
     "cuda10.1-cudnn7-ubuntu18.04-manylinux2010-multipython": "sha256:bd7666d1ef49b2b2e2a64981f1c9234deeccdb0d5198b30ff4289c3dfcffedbf",
     "cuda11.0-cudnn8-ubuntu18.04-manylinux2010-multipython": "sha256:3e5c991f67e2cca610cb9f6b39927e3757ba1e7f2424d18cef8b871bfa4d75b3",
-    "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython": "sha256:3526af54c9da9cbed2478815af42541b17617912d676fe80291a648d2825582d",
+    "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython": "sha256:6bb0678487a758ffe9384a55b51336d22180d9a75e960d988b9f6543a12b51fe",
     "rocm-ubuntu18.04-manylinux2010-multipython": "sha256:07ebbcd24eb1ec0819c0a57f789808ddd3f293f210efbb9e0525c22dc44729a2",
     "windows-1803": "sha256:f109576c7c0c8a1783ff22b666e8923b52dbbe7933f69a1c7a7275202c304a12",
 }


### PR DESCRIPTION
The current cuda11.2 container for RBE doesn't have Python 3.9 installed, but this one (from :latest) does.