### PR TITLE
Bump ROCM RBE container

### DIFF
--- a/toolchains/remote_config/containers.bzl
+++ b/toolchains/remote_config/containers.bzl
@@ -18,7 +18,7 @@ container_digests = {
     "cuda11.1-cudnn8-ubuntu18.04-manylinux2010-multipython": "sha256:db18e2a8d4c6533fb9271ad0ec13f100a2f7688b3814cb166dfb43ae583fbb94",
     "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython": "sha256:c20ba79d984078c55c07cdb142999e05559d40d8b3f83ed00dbe7510c5bad2a4",
     "cuda11.4-cudnn8.2-ubuntu18.04-manylinux2010-multipython": "sha256:9d7f3b28056a0ebe62077ad6b93c26a633d8a6d56fe97427c6145e068c657a1c",
-    "rocm-ubuntu18.04-manylinux2010-multipython": "sha256:e75f0227fb156e26b8c9e3d44ebd98d1b80a10f783763216091da5e7de108769",
+    "rocm-ubuntu18.04-manylinux2010-multipython": "sha256:d96925dd7c3aa5e3be37c6487959b44bcb2650943c3f28bded4c9632718c2124",
     "windows-1803": "sha256:f109576c7c0c8a1783ff22b666e8923b52dbbe7933f69a1c7a7275202c304a12",
 }
 


### PR DESCRIPTION
The new container has ROCM 4.3.1 instead of ROCM 4.2