### PR TITLE
add config and image for manylinux2014

### DIFF
--- a/toolchains/remote_config/configs.bzl
+++ b/toolchains/remote_config/configs.bzl
@@ -220,6 +220,32 @@ def initialize_rbe_configs():
         python_install_path = "/usr/local",
     )
 
+    tensorflow_rbe_config(
+        name = "ubuntu18.04-clang_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2",
+        compiler = "/clang_r7f6f9f4cf966c78a315d15d6e913c43cfa45c47c/bin/clang",
+        cuda_version = "11.2",
+        cudnn_version = "8.1",
+        os = "ubuntu18.04-manylinux2014-multipython",
+        python_versions = ["3.7", "3.8", "3.9"],
+        tensorrt_install_path = "/usr",
+        tensorrt_version = "7.2",
+        sysroot = "/dt8",
+        python_install_path = "/usr/local",
+    )
+    
+    tensorflow_rbe_config(
+        name = "ubuntu18.04-gcc8_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2",
+        compiler = "/dt8/usr/bin/gcc",
+        compiler_prefix = "/usr/bin",
+        cuda_version = "11.2",
+        cudnn_version = "8.1",
+        os = "ubuntu18.04-manylinux2014-multipython",
+        python_versions = ["3.7", "3.8", "3.9"],
+        tensorrt_install_path = "/usr",
+        tensorrt_version = "7.2",
+        python_install_path = "/usr/local",
+    )
+
     tensorflow_rbe_win_config(
         name = "windows_py37",
         python_bin_path = "C:/Python37/python.exe",

--- a/toolchains/remote_config/containers.bzl
+++ b/toolchains/remote_config/containers.bzl
@@ -19,6 +19,7 @@ container_digests = {
     "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython": "sha256:c20ba79d984078c55c07cdb142999e05559d40d8b3f83ed00dbe7510c5bad2a4",
     "cuda11.4-cudnn8.0.5-ubuntu18.04-manylinux2010-multipython": "sha256:dd2949ce08655001721360dde3905939152c18f6cf6be74e975c6d6a3a98791f",
     "cuda11.4-cudnn8.2-ubuntu18.04-manylinux2010-multipython": "sha256:9d7f3b28056a0ebe62077ad6b93c26a633d8a6d56fe97427c6145e068c657a1c",
+    "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2014-multipython": "sha256:279f77a04b1a00d590126ca8e5fa3d2dc98958100ceb18121fe9dbc9820b0f08",
     "rocm-ubuntu18.04-manylinux2010-multipython": "sha256:d96925dd7c3aa5e3be37c6487959b44bcb2650943c3f28bded4c9632718c2124",
     "windows-1803": "sha256:f109576c7c0c8a1783ff22b666e8923b52dbbe7933f69a1c7a7275202c304a12",
 }
@@ -99,6 +100,13 @@ containers = {
         "registry": "gcr.io",
         "repository": "tensorflow-testing/nosla-cuda11.4-cudnn8.2-ubuntu18.04-manylinux2010-multipython",
         "digest": container_digests["cuda11.4-cudnn8.2-ubuntu18.04-manylinux2010-multipython"],
+    },
+
+    # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda11.2-cudnn8.1-ubuntu18.04-manylinux2014-multipython.
+    "cuda11.2-cudnn8.1-ubuntu18.04-manylinux2014-multipython": {
+        "registry": "gcr.io",
+        "repository": "tensorflow-testing/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2014-multipython",
+        "digest": container_digests["cuda11.2-cudnn8.1-ubuntu18.04-manylinux2014-multipython"],
     },
 
     # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu18.04-manylinux2010-multipython.


### PR DESCRIPTION
 Part of updating TensorFlow's build environment compatibility to manylinux2014. 

Changes include:
* Docker image containing manylinux2014 compatible glibc and libstdc++ libraries
* RBE config for manylinux2014 that points to the devtoolset-8 enviroment, i.e, /dt8