### PR TITLE
Add experimental SIG Build RBE + toolchain configuration

### DIFF
--- a/toolchains/remote_config/configs.bzl
+++ b/toolchains/remote_config/configs.bzl
@@ -246,6 +246,43 @@ def initialize_rbe_configs():
         python_install_path = "/usr/local",
     )
 
+    # Experimental SIG Build RBE Config
+    # Since the TF team only uses one version of Python in its RBE CI, only one
+    # version is specified here. The crosstool generated from this config is
+    # python-version-independent because it only cares about the tooling paths.
+    sigbuild_tf_config(
+        name = "sigbuild-r2.9",
+        container = "docker://gcr.io/tensorflow-sigs/build@sha256:0a2e12ca7ab8536a31f1854f72510986a6792413c9d5815535486571664402d8",  # Python 3.9 container
+        env = {
+            "ABI_LIBC_VERSION": "glibc_2.19",
+            "ABI_VERSION": "gcc",
+            "BAZEL_COMPILER": "/dt7/usr/bin/gcc",
+            "BAZEL_HOST_SYSTEM": "i686-unknown-linux-gnu",
+            "BAZEL_TARGET_CPU": "k8",
+            "BAZEL_TARGET_LIBC": "glibc_2.19",
+            "BAZEL_TARGET_SYSTEM": "x86_64-unknown-linux-gnu",
+            "CC": "/dt7/usr/bin/gcc",
+            "CC_TOOLCHAIN_NAME": "linux_gnu_x86",
+            "CLEAR_CACHE": "1",
+            "CUDNN_INSTALL_PATH": "/usr/lib/x86_64-linux-gnu",
+            "GCC_HOST_COMPILER_PATH": "/dt7/usr/bin/gcc",
+            "GCC_HOST_COMPILER_PREFIX": "/usr/bin",
+            "HOST_CXX_COMPILER": "/dt7/usr/bin/gcc",
+            "HOST_C_COMPILER": "/dt7/usr/bin/gcc",
+            "PYTHON_BIN_PATH": "/usr/bin/python3"
+            "TENSORRT_INSTALL_PATH": "/usr/lib/x86_64-linux-gnu",
+            "TF_CUDA_CLANG": "0",
+            "TF_CUDA_COMPUTE_CAPABILITIES": "3.5,6.0",
+            "TF_CUDA_VERSION": "8.1",
+            "TF_CUDNN_VERSION": "11.2",
+            "TF_ENABLE_XLA": "1",
+            "TF_NEED_CUDA": "1",
+            "TF_NEED_TENSORRT": "1",
+            "TF_SYSROOT": "/dt7",
+            "TF_TENSORRT_VERSION": "7.2"
+        },
+    )
+
     tensorflow_rbe_win_config(
         name = "windows_py37",
         python_bin_path = "C:/Python37/python.exe",

--- a/toolchains/remote_config/configs.bzl
+++ b/toolchains/remote_config/configs.bzl
@@ -1,6 +1,6 @@
 """Configurations of RBE builds used with remote config."""
 
-load("//toolchains/remote_config:rbe_config.bzl", "tensorflow_local_config", "tensorflow_rbe_config", "tensorflow_rbe_win_config")
+load("//toolchains/remote_config:rbe_config.bzl", "tensorflow_local_config", "tensorflow_rbe_config", "tensorflow_rbe_win_config", "sigbuild_tf_config")
 
 def initialize_rbe_configs():
     tensorflow_local_config(
@@ -246,6 +246,11 @@ def initialize_rbe_configs():
         python_install_path = "/usr/local",
     )
 
+    tensorflow_rbe_win_config(
+        name = "windows_py37",
+        python_bin_path = "C:/Python37/python.exe",
+    )
+
     # Experimental SIG Build RBE Config
     # Since the TF team only uses one version of Python in its RBE CI, only one
     # version is specified here. The crosstool generated from this config is
@@ -269,7 +274,7 @@ def initialize_rbe_configs():
             "GCC_HOST_COMPILER_PREFIX": "/usr/bin",
             "HOST_CXX_COMPILER": "/dt7/usr/bin/gcc",
             "HOST_C_COMPILER": "/dt7/usr/bin/gcc",
-            "PYTHON_BIN_PATH": "/usr/bin/python3"
+            "PYTHON_BIN_PATH": "/usr/bin/python3",
             "TENSORRT_INSTALL_PATH": "/usr/lib/x86_64-linux-gnu",
             "TF_CUDA_CLANG": "0",
             "TF_CUDA_COMPUTE_CAPABILITIES": "3.5,6.0",
@@ -283,7 +288,3 @@ def initialize_rbe_configs():
         },
     )
 
-    tensorflow_rbe_win_config(
-        name = "windows_py37",
-        python_bin_path = "C:/Python37/python.exe",
-    )

--- a/toolchains/remote_config/rbe_config.bzl
+++ b/toolchains/remote_config/rbe_config.bzl
@@ -199,9 +199,8 @@ def sigbuild_tf_config(name, container, env):
     )
 
     remote_python_configure(
-        name = "%s_config_python" % (name, version),
+        name = "%s_config_python" % name,
         environ = env,
         exec_properties = exec_properties,
         platform_constraint = "@%s_config_platform//:platform_constraint" % name,
     )
-

--- a/toolchains/remote_config/rbe_config.bzl
+++ b/toolchains/remote_config/rbe_config.bzl
@@ -163,3 +163,45 @@ def _tensorflow_local_config(name):
 tensorflow_rbe_config = _tensorflow_rbe_config
 tensorflow_rbe_win_config = _tensorflow_rbe_win_config
 tensorflow_local_config = _tensorflow_local_config
+
+# Streamlined platform configuration for the SIG Build containers. Experimental.
+# See https://github.com/tensorflow/build/tree/master/tf_sig_build_dockerfiles
+# These containers do not support ROCm and all have CUDA, so configuration is
+# very straightforward.
+def sigbuild_tf_config(name, container, env):
+    exec_properties = {
+        "container-image": container,
+        "Pool": "default",
+    }
+
+    remote_cuda_configure(
+        name = "%s_config_cuda" % name,
+        environ = env,
+        exec_properties = exec_properties,
+    )
+
+    remote_nccl_configure(
+        name = "%s_config_nccl" % name,
+        environ = env,
+        exec_properties = exec_properties,
+    )
+
+    remote_tensorrt_configure(
+        name = "%s_config_tensorrt" % name,
+        environ = env,
+        exec_properties = exec_properties,
+    )
+
+    remote_platform_configure(
+        name = "%s_config_platform" % name,
+        platform = "linux",
+        platform_exec_properties = exec_properties,
+    )
+
+    remote_python_configure(
+        name = "%s_config_python" % (name, version),
+        environ = env,
+        exec_properties = exec_properties,
+        platform_constraint = "@%s_config_platform//:platform_constraint" % name,
+    )
+


### PR DESCRIPTION
I'm experimenting with a toolchain based specifically on the SIG Build
dockerfiles. Since they were created to match these pre-existing
toolchains, their configuration is actually the same for the most part,
except I've ripped out all of the conditional options to instead specify
env parameters explicitly.

The platform is called "sigbuild-r2.9". My line of thinking is:
internally, the DevInfra team only uses one RBE configuration at a time,
which is currently based on Python 3.9. tensorflow/toolchains must
retain previous *toolchain* configurations (not RBE configurations) for
future patch releases of TensorFlow. Therefore, much like the way the
containers are always tagged with the upcoming release version, I figure
we can continuously update the latest+1 toolchain with however we're
building at master HEAD, and once the branch is cut, create a new config
and use it in the dockerfiles instead.

For instance, the next version of TF is 2.9. The dockerfiles therefore
reference the "@sigbuild-r2.9" toolchain, which is configured here to
use CUDA 11.2. Whenever the containers are updated, they get pushed to
the "latest" and "2.9" tags. After the "next" version of TF changes to
2.10 when the branch is cut, we'd create a new "@sigbuild-r2.10"
toolchain here (with, say, CUDA 11.4, but it doesn't need to change) or
promote an ongoing testing toolchain, and change the toolchain
referenced in the dockerfiles. That way, the old 2.9 containers -- which
are now static -- correctly reference the 2.9 toolchain, which remains
available.

That's the idea, anyway; I need to do more testing to see if this will
work out correctly.
